### PR TITLE
Closes #24 Rename `avg` column to `med`

### DIFF
--- a/src/pytest_durations/reporting.py
+++ b/src/pytest_durations/reporting.py
@@ -8,10 +8,10 @@ from typing import Callable, cast
 ReportRowT = tuple[str, str, str, str, str, str]
 TimeValuesT = tuple[str, int, float, float, float, float]
 
-# columns: 0 - name, 1 - calls, 2 - min, 3 - max, 4 - avg, 5 - sum
+# columns: 0 - name, 1 - calls, 2 - min, 3 - max, 4 - med, 5 - sum
 _SUM_COLUMN_IDX = 5  # sum
 _SORT_COLUMN_IDX = 5  # sum
-_COLUMNS_ORDER = (5, 0, 1, 4, 2, 3)  # sum, name, calls, avg, min, max
+_COLUMNS_ORDER = (5, 0, 1, 4, 2, 3)  # sum, name, calls, med, min, max
 _GRAND_TOTAL_STR = "grand total"
 
 
@@ -51,7 +51,7 @@ def get_report_max_widths(report_rows: Collection[ReportRowT]) -> tuple[int, int
 
 def _get_report_header_row() -> ReportRowT:
     """Return report header row."""
-    return "name", "num", "min", "max", "avg", "total"
+    return "name", "num", "min", "max", "med", "total"
 
 
 def _get_report_footer_row(time_values: list[TimeValuesT]) -> ReportRowT:
@@ -66,7 +66,7 @@ def _get_report_footer_row(time_values: list[TimeValuesT]) -> ReportRowT:
             str(_reduce(1, sum)),  # calls
             str(timedelta(seconds=_reduce(2, min))),  # min time
             str(timedelta(seconds=_reduce(3, max))),  # max time
-            str(timedelta(seconds=_reduce(4, median))),  # avg time
+            str(timedelta(seconds=_reduce(4, median))),  # med time
             str(timedelta(seconds=_reduce(5, sum))),  # sum time
         )
         if time_values

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -14,7 +14,7 @@ def sample_measurements() -> dict[str, list[float]]:
 @pytest.fixture
 def expected_report_rows() -> list[tuple[str, str, str, str, str, str]]:
     return [
-        ("total", "name", "num", "avg", "min", "max"),
+        ("total", "name", "num", "med", "min", "max"),
         ("0:00:03.700000", "fixture2", "3", "0:00:01.200000", "0:00:01.100000", "0:00:01.400000"),
         ("0:00:00.700000", "fixture1", "3", "0:00:00.200000", "0:00:00.100000", "0:00:00.400000"),
         ("0:00:04.400000", "grand total", "6", "0:00:00.700000", "0:00:00.100000", "0:00:01.400000"),
@@ -31,7 +31,7 @@ def test_get_report_rows_empty_result():
     """Show header and zeroed footer rows only (empty report)."""
     result = get_report_rows(measurements={})
     assert result == [
-        ("total", "name", "num", "avg", "min", "max"),
+        ("total", "name", "num", "med", "min", "max"),
         ("0:00:00", "grand total", "0", "0:00:00", "0:00:00", "0:00:00"),
     ]
 


### PR DESCRIPTION
The name of the column `avg` is misleading because its values are actually median values.

Linked issue #24