### PR TITLE
Improve column alignment in duration reports

### DIFF
--- a/src/pytest_durations/plugin.py
+++ b/src/pytest_durations/plugin.py
@@ -1,6 +1,7 @@
 """Plugin main implementation logic."""
 from collections.abc import Iterable
 from contextlib import ExitStack, contextmanager
+from itertools import count
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -121,7 +122,10 @@ class PytestDurationPlugin:
         for section_name, category_report_rows in reports:
             terminalreporter.write_sep(sep="=", title=section_name, fullwidth=fullwidth)
             for idx, row in enumerate(category_report_rows):
-                content = " ".join(f"{col: {'>' if idx else '<'}{width}}" for col, width in zip(row, widths))
+                content = " ".join(
+                    f"{col:{'>' if idx and c else '<'}{width}}"  # align columns right except test name column
+                    for col, width, c in zip(row, widths, count(-1))
+                )
                 terminalreporter.line(content)
 
     @contextmanager

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -57,14 +57,14 @@ def sample_result_log():
 @pytest.fixture
 def expected_output_lines():
     return [
-        "*fixture duration top*",
-        "*grand total   7*",
-        "*test call duration top*",
-        "*grand total   2*",
-        "*test setup duration top*",
-        "*grand total   2*",
-        "*test teardown duration top*",
-        "*grand total   2*",
+        "* fixture duration top *",
+        "* grand total * 7 *",
+        "* test call duration top *",
+        "* grand total * 2 *",
+        "* test setup duration top *",
+        "* grand total * 2 *",
+        "* test teardown duration top *",
+        "* grand total * 2 *",
     ]
 
 


### PR DESCRIPTION
This PR fixes the column alignment in the duration reports to properly right-align all columns except for test names, which should remain left-aligned for better readability.