### PR TITLE
Remove Category xdist serialization/deserialization

### DIFF
--- a/src/pytest_durations/types.py
+++ b/src/pytest_durations/types.py
@@ -1,5 +1,23 @@
 """Type declarations module."""
+from collections.abc import Iterator
 from enum import Enum
+
+
+class CategoryMeta(type):
+    """Category should be a plain string, but compatible with Enum class iterator."""
+
+    def __iter__(cls) -> Iterator[str]:
+        """Return enumeration of class field values."""
+        return (v for k, v in cls.__dict__.items() if not k.startswith("__"))
+
+
+class Category(metaclass=CategoryMeta):
+    """Measurement category constants."""
+
+    FIXTURE_SETUP = "fixture"
+    TEST_CALL = "test call"
+    TEST_SETUP = "test setup"
+    TEST_TEARDOWN = "test teardown"
 
 
 class StrEnum(str, Enum):
@@ -8,24 +26,6 @@ class StrEnum(str, Enum):
     def __str__(self) -> str:
         """Return the current value (expected to be a string)."""
         return self.value
-
-    def save(self) -> str:
-        """Serialize StrEnum to a plain string."""
-        return self.name
-
-    @classmethod
-    def load(cls, name: str) -> "StrEnum":
-        """Deserialize StrEnum from a plain string."""
-        return cls[name]
-
-
-class Category(StrEnum):
-    """Measurement category constants."""
-
-    FIXTURE_SETUP = "fixture"
-    TEST_CALL = "test call"
-    TEST_SETUP = "test setup"
-    TEST_TEARDOWN = "test teardown"
 
 
 class GroupBy(StrEnum):

--- a/src/pytest_durations/typing.pyi
+++ b/src/pytest_durations/typing.pyi
@@ -1,8 +1,8 @@
 # Note: only simple data types can be used for communication between master and worker xdist processes
-from pytest_durations.types import Category
 
 FunctionKeyT = str
 DurationListT = list[float]
 FunctionMeasurementsT = dict[FunctionKeyT, DurationListT]
 
-CategoryMeasurementsT = dict[Category, FunctionMeasurementsT]
+CategoryT = str
+CategoryMeasurementsT = dict[CategoryT, FunctionMeasurementsT]

--- a/src/pytest_durations/xdist.py
+++ b/src/pytest_durations/xdist.py
@@ -3,8 +3,6 @@ from typing import TYPE_CHECKING, Any, Optional, Union
 
 import pytest
 
-from pytest_durations.types import Category
-
 if TYPE_CHECKING:
     from _pytest.config import ExitCode
     from _pytest.main import Session
@@ -41,15 +39,12 @@ class PytestDurationXdistMixin:
 
 def dump_measurements(measurements: "CategoryMeasurementsT") -> dict[str, "FunctionMeasurementsT"]:
     """Serialize category measurement mapping with simple types only."""
-    return {
-        category.save(): measurements
-        for category, measurements in measurements.items()
-    }
+    return measurements
 
 
 def load_measurements(measurements: dict[str, "FunctionMeasurementsT"], destination: "CategoryMeasurementsT") -> None:
     """Deserialize category measurement mapping into an existing object."""
     for category, src_series in measurements.items():
-        dst_series = destination[Category.load(category)]
+        dst_series = destination[category]
         for key, values in src_series.items():
             dst_series.setdefault(key, []).extend(values)


### PR DESCRIPTION
This PR removes the custom serialization (save) and deserialization (load) methods for the Category enum, as well as the StrEnum base class for Category. Instead, Category is redefined using a metaclass (CategoryMeta) to provide iteration capabilities while being fundamentally a plain string type.

The primary motivation is to simplify the data types used for communication between master and worker processes in xdist. The Category type is now represented as a simple str in type hints (CategoryT = str in typing.pyi), removing the need for explicit serialization steps when sending CategoryMeasurementsT dictionaries over the wire. The dump_measurements function now simply passes the dictionary through, and load_measurements uses the string keys directly as dictionary keys for the destination.

This change aims to make the xdist communication more robust and efficient by relying on native, serializable types.