### PR TITLE
Add "none" grouping option and improve fixture key handling

### DIFF
--- a/src/pytest_durations/helpers.py
+++ b/src/pytest_durations/helpers.py
@@ -60,12 +60,12 @@ def get_grouped_measurements(
 
 def _test_group_by_legacy(item: "MeasurementItemT") -> "FunctionKeyT":
     # keep class and test name only (old behaviour before grouping)
-    return item[0].split("::", 1)[-1]
+    return _remove_params_from_key(item[0].split("::", 1)[-1])
 
 
 def _fixture_group_by_legacy(item: "MeasurementItemT") -> "FunctionKeyT":
     # keep fixture name only (old behaviour before grouping)
-    return item[0].rsplit("::", 1)[-1]
+    return _remove_params_from_key(item[0].rsplit("::", 1)[-1])
 
 
 def _group_by_module(item: "MeasurementItemT") -> "FunctionKeyT":
@@ -86,7 +86,7 @@ def _group_by_class(item: "MeasurementItemT") -> "FunctionKeyT":
 
 def _group_by_function(item: "MeasurementItemT") -> "FunctionKeyT":
     # remove parameters mark
-    return item[0].split("[", 1)[0]
+    return _remove_params_from_key(item[0])
 
 
 def _group_by_none(item: "MeasurementItemT") -> "FunctionKeyT":
@@ -110,3 +110,7 @@ _GROUPING_FUNC_MAP: Mapping["GroupingKindT", Mapping["GroupBy", "GroupingCbT"]] 
         GroupBy.NONE: _group_by_none,
     },
 }
+
+
+def _remove_params_from_key(key: str) -> str:
+    return key.rsplit("[", 1)[0]

--- a/src/pytest_durations/helpers.py
+++ b/src/pytest_durations/helpers.py
@@ -26,7 +26,7 @@ def is_shared_fixture(fixturedef: "FixtureDef") -> bool:
 
 def get_fixture_key(fixturedef: "FixtureDef", item: "Item") -> "FunctionKeyT":
     """Return fixture measurements dict key."""
-    baseid = fixturedef.baseid if fixturedef.baseid else get_test_key(item=item)
+    baseid = fixturedef.baseid if fixturedef.baseid or not fixturedef.has_location else get_test_key(item=item)
     return "::".join(filter(None, (baseid, fixturedef.argname)))
 
 

--- a/src/pytest_durations/helpers.py
+++ b/src/pytest_durations/helpers.py
@@ -32,7 +32,7 @@ def get_fixture_key(fixturedef: "FixtureDef", item: "Item") -> "FunctionKeyT":
 
 def get_test_key(item: "Item") -> "FunctionKeyT":
     """Return test item measurements dict key."""
-    return item.nodeid.split("[", 1)[0]
+    return item.nodeid
 
 
 def _get_grouping_func(kind: "GroupingKindT", group_by: "GroupBy") -> "GroupingCbT":
@@ -85,6 +85,11 @@ def _group_by_class(item: "MeasurementItemT") -> "FunctionKeyT":
 
 
 def _group_by_function(item: "MeasurementItemT") -> "FunctionKeyT":
+    # remove parameters mark
+    return item[0].split("[", 1)[0]
+
+
+def _group_by_none(item: "MeasurementItemT") -> "FunctionKeyT":
     # keep name as is
     return item[0]
 
@@ -95,11 +100,13 @@ _GROUPING_FUNC_MAP: Mapping["GroupingKindT", Mapping["GroupBy", "GroupingCbT"]] 
         GroupBy.MODULE: _group_by_module,
         GroupBy.CLASS: _group_by_class,
         GroupBy.FUNCTION: _group_by_function,
+        GroupBy.NONE: _group_by_none,
     },
     "fixture": {
         GroupBy.LEGACY: _fixture_group_by_legacy,
         GroupBy.MODULE: _group_by_module,
         GroupBy.CLASS: _group_by_class,
         GroupBy.FUNCTION: _group_by_function,
+        GroupBy.NONE: _group_by_none,
     },
 }

--- a/src/pytest_durations/options.py
+++ b/src/pytest_durations/options.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 DEFAULT_DURATIONS = 30
 DEFAULT_DURATIONS_MIN = 0.005
 DEFAULT_RESULT_LOG = "-"
+DEFAULT_GROUP_BY = GroupBy.FUNCTION
 
 
 def pytest_addoption(parser: "Parser", pluginmanager: "PytestPluginManager") -> None:
@@ -43,11 +44,11 @@ def pytest_addoption(parser: "Parser", pluginmanager: "PytestPluginManager") -> 
     group.addoption(
         "--pytest-durations-group-by",
         type=GroupBy,
-        default=GroupBy.FUNCTION,
+        default=DEFAULT_GROUP_BY,
         choices=[*GroupBy],
         help=f'Group test durations by module, class, or function.'
              f' Use legacy grouping for backward compatibility.'
-             f' Default: "{GroupBy.FUNCTION}"',
+             f' Default: "{DEFAULT_GROUP_BY}"',
     )
 
 

--- a/src/pytest_durations/types.py
+++ b/src/pytest_durations/types.py
@@ -35,3 +35,4 @@ class GroupBy(StrEnum):
     MODULE = "module"
     CLASS = "class"
     FUNCTION = "function"
+    NONE = "none"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -130,53 +130,70 @@ class TestTestGroupBy:
         def assertion(group_by: "GroupBy") -> bool:
             (sample, expected), grouping_func = rule, _GROUPING_FUNC_MAP["test"][group_by]
             result = grouping_func((sample, [1.0]))
-            return result == expected
+            assert result == expected
+            return True
 
         return assertion
 
     @pytest.mark.parametrize(
         "rule",
         [
+            ("module.py::scope::function[param]", "scope::function"),
             ("module.py::scope::function", "scope::function"),
             ("module.py::function", "function"),
             ("function", "function"),
         ],
     )
     def test_group_by_legacy(self, assertion, rule):
-        assert assertion(group_by=GroupBy.LEGACY) is True
+        assertion(group_by=GroupBy.LEGACY)
 
     @pytest.mark.parametrize(
         "rule",
         [
+            ("module.py::scope::function[param]", "module.py"),
             ("module.py::scope::function", "module.py"),
             ("module.py::function", "module.py"),
             ("function", "uncertain"),
         ],
     )
     def test_group_by_module(self, assertion, rule):
-        assert assertion(group_by=GroupBy.MODULE) is True
+        assertion(group_by=GroupBy.MODULE)
 
     @pytest.mark.parametrize(
         "rule",
         [
+            ("module.py::scope::function[param]", "module.py::scope"),
             ("module.py::scope::function", "module.py::scope"),
             ("module.py::function", "module.py::"),
             ("function", "uncertain::function"),
         ],
     )
     def test_group_by_class(self, assertion, rule):
-        assert assertion(group_by=GroupBy.CLASS) is True
+        assertion(group_by=GroupBy.CLASS)
 
     @pytest.mark.parametrize(
         "rule",
         [
+            ("module.py::scope::function[param]", "module.py::scope::function"),
             ("module.py::scope::function", "module.py::scope::function"),
             ("module.py::function", "module.py::function"),
             ("function", "function"),
         ],
     )
     def test_group_by_function(self, assertion, rule):
-        assert assertion(group_by=GroupBy.FUNCTION) is True
+        assertion(group_by=GroupBy.FUNCTION)
+
+    @pytest.mark.parametrize(
+        "rule",
+        [
+            ("module.py::scope::function[param]", "module.py::scope::function[param]"),
+            ("module.py::scope::function", "module.py::scope::function"),
+            ("module.py::function", "module.py::function"),
+            ("function", "function"),
+        ],
+    )
+    def test_group_by_none(self, assertion, rule):
+        assertion(group_by=GroupBy.NONE)
 
 
 class TestFixtureGroupBy:
@@ -192,6 +209,7 @@ class TestFixtureGroupBy:
     @pytest.mark.parametrize(
         "rule",
         [
+            ("module.py::scope::function::fixture[param]", "fixture"),
             ("module.py::scope::function::fixture", "fixture"),
             ("module.py::scope::fixture", "fixture"),
             ("module.py::function::fixture", "fixture"),
@@ -200,11 +218,12 @@ class TestFixtureGroupBy:
         ],
     )
     def test_group_by_legacy(self, assertion, rule):
-        assert assertion(group_by=GroupBy.LEGACY) is True
+        assertion(group_by=GroupBy.LEGACY)
 
     @pytest.mark.parametrize(
         "rule",
         [
+            ("module.py::scope::function::fixture[param]", "module.py"),
             ("module.py::scope::function::fixture", "module.py"),
             ("module.py::scope::fixture", "module.py"),
             ("module.py::function::fixture", "module.py"),
@@ -213,11 +232,12 @@ class TestFixtureGroupBy:
         ],
     )
     def test_group_by_module(self, assertion, rule):
-        assert assertion(group_by=GroupBy.MODULE) is True
+        assertion(group_by=GroupBy.MODULE)
 
     @pytest.mark.parametrize(
         "rule",
         [
+            ("module.py::scope::function::fixture[param]", "module.py::scope::function"),
             ("module.py::scope::function::fixture", "module.py::scope::function"),
             ("module.py::scope::fixture", "module.py::scope"),
             ("module.py::function::fixture", "module.py::function"),
@@ -226,11 +246,12 @@ class TestFixtureGroupBy:
         ],
     )
     def test_group_by_class(self, assertion, rule):
-        assert assertion(group_by=GroupBy.CLASS) is True
+        assertion(group_by=GroupBy.CLASS)
 
     @pytest.mark.parametrize(
         "rule",
         [
+            ("module.py::scope::function::fixture[param]", "module.py::scope::function::fixture"),
             ("module.py::scope::function::fixture", "module.py::scope::function::fixture"),
             ("module.py::scope::fixture", "module.py::scope::fixture"),
             ("module.py::function::fixture", "module.py::function::fixture"),
@@ -239,4 +260,17 @@ class TestFixtureGroupBy:
         ],
     )
     def test_group_by_function(self, assertion, rule):
-        assert assertion(group_by=GroupBy.FUNCTION) is True
+        assertion(group_by=GroupBy.FUNCTION)
+
+    @pytest.mark.parametrize(
+        "rule",
+        [
+            ("module.py::scope::function::fixture[param]", "module.py::scope::function::fixture[param]"),
+            ("module.py::scope::fixture", "module.py::scope::fixture"),
+            ("module.py::function::fixture", "module.py::function::fixture"),
+            ("module.py::fixture", "module.py::fixture"),
+            ("fixture", "fixture"),
+        ],
+    )
+    def test_group_by_none(self, assertion, rule):
+        assertion(group_by=GroupBy.NONE)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -58,7 +58,7 @@ class TestGetFixtureKey:
         [
             (module_level.__name__, "tests/test_helpers.py::module_level"),
             (class_level.__name__, "tests/test_helpers.py::TestGetFixtureKey::class_level"),
-            ("rule", "tests/test_helpers.py::TestGetFixtureKey::test_get_fixture_key::rule"),
+            ("rule", "tests/test_helpers.py::TestGetFixtureKey::test_get_fixture_key[rule2]::rule"),
         ],
     )
     @pytest.mark.usefixtures("module_level", "class_level")
@@ -77,7 +77,7 @@ class TestGetTestKey:
     @pytest.mark.parametrize("param", [None])
     def test_get_test_key_parametrized(self, request: "FixtureRequest", param):
         result = get_test_key(item=request.node)
-        assert result == "tests/test_helpers.py::TestGetTestKey::test_get_test_key_parametrized"
+        assert result == "tests/test_helpers.py::TestGetTestKey::test_get_test_key_parametrized[None]"
 
 
 class TestGetGroupingFunc:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -59,10 +59,11 @@ class TestGetFixtureKey:
             (module_level.__name__, "tests/test_helpers.py::module_level"),
             (class_level.__name__, "tests/test_helpers.py::TestGetFixtureKey::class_level"),
             ("rule", "tests/test_helpers.py::TestGetFixtureKey::test_get_fixture_key[rule2]::rule"),
+            ("tmp_path_factory", "tmp_path_factory"),
         ],
     )
     @pytest.mark.usefixtures("module_level", "class_level")
-    def test_get_fixture_key(self, request: "FixtureRequest",  rule):
+    def test_get_fixture_key(self, request: "FixtureRequest", tmp_path_factory, rule):
         fixture, expected = rule
         fixturedef = request._fixture_defs[fixture]
         result = get_fixture_key(fixturedef=fixturedef, item=request.node)
@@ -223,7 +224,7 @@ class TestFixtureGroupBy:
     @pytest.mark.parametrize(
         "rule",
         [
-            ("module.py::scope::function::fixture[param]", "module.py"),
+            ("module.py::scope::function[param]::fixture", "module.py"),
             ("module.py::scope::function::fixture", "module.py"),
             ("module.py::scope::fixture", "module.py"),
             ("module.py::function::fixture", "module.py"),
@@ -237,7 +238,7 @@ class TestFixtureGroupBy:
     @pytest.mark.parametrize(
         "rule",
         [
-            ("module.py::scope::function::fixture[param]", "module.py::scope::function"),
+            ("module.py::scope::function[param]::fixture", "module.py::scope::function[param]"),
             ("module.py::scope::function::fixture", "module.py::scope::function"),
             ("module.py::scope::fixture", "module.py::scope"),
             ("module.py::function::fixture", "module.py::function"),
@@ -251,7 +252,7 @@ class TestFixtureGroupBy:
     @pytest.mark.parametrize(
         "rule",
         [
-            ("module.py::scope::function::fixture[param]", "module.py::scope::function::fixture"),
+            ("module.py::scope::function[param]::fixture", "module.py::scope::function[param]::fixture"),
             ("module.py::scope::function::fixture", "module.py::scope::function::fixture"),
             ("module.py::scope::fixture", "module.py::scope::fixture"),
             ("module.py::function::fixture", "module.py::function::fixture"),
@@ -265,7 +266,7 @@ class TestFixtureGroupBy:
     @pytest.mark.parametrize(
         "rule",
         [
-            ("module.py::scope::function::fixture[param]", "module.py::scope::function::fixture[param]"),
+            ("module.py::scope::function[param]::fixture", "module.py::scope::function[param]::fixture"),
             ("module.py::scope::fixture", "module.py::scope::fixture"),
             ("module.py::function::fixture", "module.py::function::fixture"),
             ("module.py::fixture", "module.py::fixture"),


### PR DESCRIPTION
This PR introduces a new GroupBy.NONE option that preserves the full test node ID, including parameters, when grouping measurements. It also refines the logic for generating fixture keys.