### PR TITLE
up min pytest version from 4.6 to 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ $ pytest
 
 * todo: describe new features here
 
+* up support pytest version to 8.0.0+
+
+
 
 ## Change Log
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2136,4 +2136,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "8da48bd1c0fb62d15e2b3e8d9667a763cc611afe417451c00297ed5879b9599a"
+content-hash = "49a1f74d32d5fd5dabd45e6135258ebde0781211f6d1b985c1da692d23bef8a3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1261,21 +1261,21 @@ files = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b"},
+    {file = "pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -2136,4 +2136,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "de39ecc4733ebef5530ec33af02c4892922964f2d041e4f5fa57a2773f4a035e"
+content-hash = "8da48bd1c0fb62d15e2b3e8d9667a763cc611afe417451c00297ed5879b9599a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ include = ["LICENSE"]
 pytest-durations = "pytest_durations"
 
 [tool.poetry.dependencies]
-pytest = ">=8.0"
+pytest = ">=7.0"
 python = ">=3.10,<4.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,15 +27,15 @@ include = ["LICENSE"]
 pytest-durations = "pytest_durations"
 
 [tool.poetry.dependencies]
-pytest = ">=4.6"
+pytest = ">=8.0"
 python = ">=3.10,<4.0"
 
 [tool.poetry.group.dev.dependencies]
 freezegun = "^1.5.5"
 pre-commit = "^3.8.0"
-pytest = "^8.3.3"
+pytest = "^9.0.2"
 pytest-cov = "^7.0.0"
-pytest-xdist = "^3.6.1"
+pytest-xdist = "^3.8.0"
 ruff = "^0.11.7"
 time-machine = "^2.19.0"
 virtualenv = "^21.2.0"


### PR DESCRIPTION
Hello.
In this PR:
1) up minimum supported pytest version from [4.6](https://docs.pytest.org/en/stable/changelog.html#pytest-4-6-0-2019-05-31) to [8.0.0](https://docs.pytest.org/en/stable/changelog.html#pytest-8-0-0-2024-01-27)
2) up unit tests run in pytest from 8.x.x to 9.0.2
