### PR TITLE
add typos in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,9 @@ repos:
         entry: .github/scripts/check_version.py
         files: 'pyproject\.toml|src\/pytest_durations\/__init__\.py|README\.md$'
         language: python
+
+      - id: typos
+        name: check-typo
+        entry: typos
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ $ pytest
 
 * todo: describe new features here
 
-* up support pytest version to 8.0.0+
+* up support pytest version to 7.0.0+
+* add typos in pre-commits
 
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1879,6 +1879,26 @@ files = [
 markers = {main = "python_version == \"3.10\"", dev = "python_version == \"3.10\"", sync = "python_version < \"3.13\""}
 
 [[package]]
+name = "typos"
+version = "1.44.0"
+description = "Source Code Spelling Correction"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "typos-1.44.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:bf4241c469c14b7213a5ce2cf2a0692be21641be1a247dc126bec3f982195d6c"},
+    {file = "typos-1.44.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:28332344a2939f20707ad0265cc10da5b930015c75920725cdd6db9ab9bdb18b"},
+    {file = "typos-1.44.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95b91c20c914a0f728d3d0ad21e0fee3fd0bd0b7514d66b1d42f6047ebbb8646"},
+    {file = "typos-1.44.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd7a3d55466896336230679bf87484074b5912f555a8c8cf6ea88c084bf5b28d"},
+    {file = "typos-1.44.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d78c219d802b124a9b90d7327665e6de20e3aba5f4ff31fb76e25c338a9475d"},
+    {file = "typos-1.44.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b3796090bdf1531cc3abd34a597d0ca5aef5c40841e49f9aeda58f1ab950e060"},
+    {file = "typos-1.44.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c6aea9c04fb9759efe94bddf8af4156707bc82de3b9b58118530f2c9818352c9"},
+    {file = "typos-1.44.0-py3-none-win32.whl", hash = "sha256:4af31b78e38e9720be009b725334108a3c4684bfc820ca8309f7ce54d72c303d"},
+    {file = "typos-1.44.0-py3-none-win_amd64.whl", hash = "sha256:3624055a8f04d9c40faf20ff0fcce9dbf4f8e2987c39680358901cc8634228c0"},
+    {file = "typos-1.44.0.tar.gz", hash = "sha256:8e1046d02f2fcea6df907b34b90556e4acafd9b287ad70ab27d2c06489f5df43"},
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -2136,4 +2156,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "49a1f74d32d5fd5dabd45e6135258ebde0781211f6d1b985c1da692d23bef8a3"
+content-hash = "eb1176228fe61b59e979db74d9ca8814d7424020ecb373d7db726e1dc9f2989b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ pytest = "^9.0.2"
 pytest-cov = "^7.0.0"
 pytest-xdist = "^3.8.0"
 ruff = "^0.11.7"
+typos = "^1.44.0"
 time-machine = "^2.19.0"
 virtualenv = "^21.2.0"
 

--- a/src/pytest_durations/measure.py
+++ b/src/pytest_durations/measure.py
@@ -7,12 +7,12 @@ from pytest_durations.ticker import get_current_ticks
 class MeasureDuration:
     """Context manager measuring duration of block execution."""
 
-    start: float  # monotonic clock value of block entrace
+    start: float  # monotonic clock value of block entrance
     end: float  # monotonic clock value of block exit
     duration: float  # duration of block execution in seconds
 
     def __enter__(self) -> "MeasureDuration":
-        """Store block entrace time."""
+        """Store block entrance time."""
         self.start = get_current_ticks()
         self.duration = 0.0
         return self

--- a/src/pytest_durations/plugin.py
+++ b/src/pytest_durations/plugin.py
@@ -145,7 +145,7 @@ class PytestDurationPlugin:
 
     @contextmanager
     def _measure(self, category: "Category", key: "FunctionKeyT") -> Iterable["MeasureDuration"]:
-        """Measure wrapping block exeution time and put it into a dict."""
+        """Measure wrapping block execution time and put it into a dict."""
         measurements = self.measurements[category]
 
         with MeasureDuration() as measurement:

--- a/src/pytest_durations/xdist.py
+++ b/src/pytest_durations/xdist.py
@@ -29,7 +29,7 @@ class PytestDurationXdistMixin:
             workeroutput[_PLUGIN_KEY] = dump_measurements(self.measurements)
 
     def pytest_testnodedown(self, node: "WorkerController", error: Any | None) -> None:
-        """Merge measurements from slave processes if the current sesions runs under pytest-xdist."""
+        """Merge measurements from slave processes if the current sessions runs under pytest-xdist."""
         # for xdist, results should be accumulated from workers
         workeroutput: dict[str, Any] | None = getattr(node, _WORKEROUTPUT_ATTR, None)
         if workeroutput is not None:


### PR DESCRIPTION
Hello.
In this PR:
1) add https://github.com/crate-ci/typos for fix typo in comments/code
2) fix warnings 

Example use typos in other projects:
https://github.com/astral-sh/ruff/blob/main/.pre-commit-config.yaml#L41
https://github.com/pytest-dev/pytest-timeout/blob/main/.pre-commit-config.yaml#L44