### PR TITLE
Release 1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ $ pytest
 
 ## Unreleased
 
-* Show max duration instead of min in reports (#47) — fixes a regression from
-  v1.3.1 where the last column was accidentally truncated.
-
 
 ## Change Log
+
+### 1.7.1 (Aug 06, 2026)
+
+* Show max duration instead of min in reports (#47) — fixes a regression from
+  v1.3.1 where the last column was accidentally truncated.
 
 ### 1.7.0 (Jul 08, 2026)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-durations"
-version = "1.7.0"
+version = "1.7.1"
 description = "Pytest plugin reporting fixtures and test functions execution time."
 authors = ["Oleg Blednov <oleg.codev@gmail.com>"]
 license = "MIT"

--- a/src/pytest_durations/__init__.py
+++ b/src/pytest_durations/__init__.py
@@ -2,4 +2,4 @@
 
 from pytest_durations.options import pytest_addoption, pytest_configure  # noqa: F401
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"


### PR DESCRIPTION
Release 1.7.1

- Show max duration instead of min in reports (#47)
  Fixes a regression from v1.3.1 where the last column was accidentally truncated.
