### PR TITLE
Add --pytest-durations-time-format presets (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ pytest-durations:
                         Group test durations by module, class, or function. Use
                         legacy grouping for backward compatibility. Default:
                         "function"
+  --pytest-durations-time-format={clock,auto,short}
+                        How to format durations in the report. "clock" shows the
+                        full datetime-style value, "short" a compact H:MM:SS, and
+                        "auto" picks one readable form based on the report
+                        magnitude. Default: "clock"
 ```
 
 Note: Please don't confuse these options with the --durations options that come from pytest itself.
@@ -85,6 +90,10 @@ $ pytest
 
 
 ## Unreleased
+
+* Added a `--pytest-durations-time-format` option with `clock`, `auto`, and `short`
+  presets for formatting durations in the report (#49). The default (`clock`) keeps the
+  existing output unchanged.
 
 
 ## Change Log

--- a/src/pytest_durations/options.py
+++ b/src/pytest_durations/options.py
@@ -1,8 +1,7 @@
 """Plugin command line arguments parsing module."""
 from typing import TYPE_CHECKING
 
-from pytest_durations.reporting import TimeFormat
-from pytest_durations.types import GroupBy
+from pytest_durations.types import GroupBy, TimeFormat
 
 if TYPE_CHECKING:
     from _pytest.config import Config, PytestPluginManager

--- a/src/pytest_durations/options.py
+++ b/src/pytest_durations/options.py
@@ -1,6 +1,7 @@
 """Plugin command line arguments parsing module."""
 from typing import TYPE_CHECKING
 
+from pytest_durations.reporting import TimeFormat
 from pytest_durations.types import GroupBy
 
 if TYPE_CHECKING:
@@ -11,6 +12,7 @@ DEFAULT_DURATIONS = 30
 DEFAULT_DURATIONS_MIN = 0.005
 DEFAULT_RESULT_LOG = "-"
 DEFAULT_GROUP_BY = GroupBy.FUNCTION
+DEFAULT_TIME_FORMAT = TimeFormat.CLOCK
 
 
 def pytest_addoption(parser: "Parser", pluginmanager: "PytestPluginManager") -> None:
@@ -49,6 +51,16 @@ def pytest_addoption(parser: "Parser", pluginmanager: "PytestPluginManager") -> 
         help=f'Group test durations by module, class, or function.'
              f' Use legacy grouping for backward compatibility.'
              f' Default: "{DEFAULT_GROUP_BY}"',
+    )
+    group.addoption(
+        "--pytest-durations-time-format",
+        type=TimeFormat,
+        default=DEFAULT_TIME_FORMAT,
+        choices=[*TimeFormat],
+        help=f'How to format durations in the report.'
+             f' "clock" shows the full datetime-style value, "short" a compact H:MM:SS,'
+             f' and "auto" picks one readable form based on the report magnitude.'
+             f' Default: "{DEFAULT_TIME_FORMAT}"',
     )
 
 

--- a/src/pytest_durations/plugin.py
+++ b/src/pytest_durations/plugin.py
@@ -17,7 +17,7 @@ from pytest_durations.helpers import (
 )
 from pytest_durations.measure import MeasureDuration
 from pytest_durations.options import DEFAULT_RESULT_LOG
-from pytest_durations.reporting import get_report_max_widths, get_report_rows
+from pytest_durations.reporting import get_report_max_widths, get_report_rows, resolve_time_format
 from pytest_durations.ticker import get_current_ticks
 from pytest_durations.types import Category
 
@@ -118,8 +118,19 @@ class PytestDurationPlugin:
         reports = []
         widths = [0] * 5
         group_by = config.getoption("--pytest-durations-group-by")
+        time_format = config.getoption("--pytest-durations-time-format")
         test_grouping_func = get_test_grouping_func(group_by=group_by)
         fixture_grouping_func = get_fixture_grouping_func(group_by=group_by)
+        max_duration = max(
+            (
+                max(times)
+                for measurements in self.measurements.values()
+                for times in measurements.values()
+                if times
+            ),
+            default=0.0,
+        )
+        format_seconds = resolve_time_format(time_format=time_format, max_seconds=max_duration)
         for category in Category:
             grouping_func = test_grouping_func if category is not Category.FIXTURE_SETUP else fixture_grouping_func
             category_measurements = get_grouped_measurements(
@@ -130,6 +141,7 @@ class PytestDurationPlugin:
                 measurements=category_measurements,
                 duration_min=durations_min,
                 max_rows=durations,
+                format_seconds=format_seconds,
             )
             reports.append((f"{category} duration top", category_report_rows))
             widths = [max(*a) for a in zip(widths, get_report_max_widths(category_report_rows), strict=False)]

--- a/src/pytest_durations/reporting.py
+++ b/src/pytest_durations/reporting.py
@@ -1,12 +1,97 @@
 """Helper to generate formatted measurement report rows from timing data."""
-from collections.abc import Collection
+from collections.abc import Callable, Collection
 from datetime import timedelta
 from operator import attrgetter
 from statistics import median
 from typing import NamedTuple
 
+from pytest_durations.types import StrEnum
+
 # Default sort field for report ordering
 _SORT_BY_DEFAULT = "sum"
+_SECONDS_PER_MINUTE = 60
+_SECONDS_PER_HOUR = 3600
+_SECONDS_PER_DAY = 86400
+
+
+class TimeFormat(StrEnum):
+    """Possible duration formatting modes for the report."""
+
+    CLOCK = "clock"
+    SHORT = "short"
+    AUTO = "auto"
+
+
+def format_seconds_clock(seconds: float) -> str:
+    """Format seconds exactly as ``str(timedelta(seconds=...))`` (default behavior)."""
+    return str(timedelta(seconds=seconds))
+
+
+def format_seconds_short(seconds: float) -> str:
+    """Format seconds as compact ``H:MM:SS`` (days folded into hours), no microseconds."""
+    total = int(seconds)
+    hours, rem = divmod(total, _SECONDS_PER_HOUR)
+    minutes, secs = divmod(rem, _SECONDS_PER_MINUTE)
+    return f"{hours}:{minutes:02d}:{secs:02d}"
+
+
+def _format_seconds_sub_second(seconds: float) -> str:
+    """Format sub-second durations in milliseconds."""
+    return f"{seconds * 1000:.0f}ms"
+
+
+def _format_seconds_millis(seconds: float) -> str:
+    """Format durations as ``SS.fff`` seconds."""
+    return f"{seconds:.3f}s"
+
+
+def _format_seconds_time(seconds: float) -> str:
+    """Format durations as ``M:SS`` minutes and seconds."""
+    total = int(seconds)
+    minutes, secs = divmod(total, _SECONDS_PER_MINUTE)
+    return f"{minutes}:{secs:02d}"
+
+
+def _format_seconds_hms(seconds: float) -> str:
+    """Format durations as ``H:MM:SS`` hours, minutes and seconds."""
+    total = int(seconds)
+    hours, rem = divmod(total, _SECONDS_PER_HOUR)
+    minutes, secs = divmod(rem, _SECONDS_PER_MINUTE)
+    return f"{hours}:{minutes:02d}:{secs:02d}"
+
+
+def _format_seconds_days(seconds: float) -> str:
+    """Format durations as ``Xd H:MM:SS`` days, hours, minutes and seconds."""
+    total = int(seconds)
+    days, rem = divmod(total, _SECONDS_PER_DAY)
+    hours, rem = divmod(rem, _SECONDS_PER_HOUR)
+    minutes, secs = divmod(rem, _SECONDS_PER_MINUTE)
+    return f"{days}d {hours}:{minutes:02d}:{secs:02d}"
+
+
+def resolve_time_format(time_format: TimeFormat, max_seconds: float) -> Callable[[float], str]:
+    """Resolve a :class:`TimeFormat` into a single concrete formatter for a whole report.
+
+    :param time_format: The requested formatting mode.
+    :param max_seconds: Global maximum duration (seconds) across all measurements, used to
+                        pick the *auto* form once for the whole report.
+    :return: A formatter callable mapping a duration (seconds) to a display string.
+    """
+    if time_format is TimeFormat.SHORT:
+        return format_seconds_short
+    if time_format is TimeFormat.CLOCK:
+        return format_seconds_clock
+    if max_seconds >= _SECONDS_PER_DAY:
+        formatter = _format_seconds_days
+    elif max_seconds >= _SECONDS_PER_HOUR:
+        formatter = _format_seconds_hms
+    elif max_seconds >= _SECONDS_PER_MINUTE:
+        formatter = _format_seconds_time
+    elif max_seconds >= 1:
+        formatter = _format_seconds_millis
+    else:
+        formatter = _format_seconds_sub_second
+    return formatter
 
 
 def get_report_rows(
@@ -14,6 +99,7 @@ def get_report_rows(
     duration_min: float = -1.0,
     max_rows: int = 0,
     sort_by: str = _SORT_BY_DEFAULT,
+    format_seconds: Callable[[float], str] = format_seconds_clock,
 ) -> list["ReportRowT"]:
     """Generate a formatted performance report from timing measurements.
 
@@ -24,6 +110,8 @@ def get_report_rows(
                      Use 0 (default) for no limit.
     :param sort_by: Field to sort by — one of: 'name', 'calls', 'min', 'max', 'med', 'sum'.
                     Default: 'sum' (descending).
+    :param format_seconds: Callable formatting a duration (seconds) into a display string.
+                           Defaults to the clock format.
     :return: List of formatted rows including header, filtered/sorted entries, and grand total.
     """
     time_values: list[TimeValuesT] = []
@@ -46,8 +134,8 @@ def get_report_rows(
 
     # Build final report: header + filtered entries + grand total
     result: list[ReportRowT] = [ReportRowT.get_header()]
-    result.extend(ReportRowT.from_time_value(time_value) for time_value in time_values)
-    result.append(ReportRowT.from_time_value(time_value_grand))
+    result.extend(ReportRowT.from_time_value(time_value, format_seconds=format_seconds) for time_value in time_values)
+    result.append(ReportRowT.from_time_value(time_value_grand, format_seconds=format_seconds))
 
     return result
 
@@ -136,13 +224,12 @@ class ReportRowT(NamedTuple):
         return cls(*cls._fields)
 
     @classmethod
-    def from_time_value(cls, time_value: TimeValuesT) -> "ReportRowT":
+    def from_time_value(
+        cls,
+        time_value: TimeValuesT,
+        format_seconds: Callable[[float], str] = format_seconds_clock,
+    ) -> "ReportRowT":
         """Format a TimeValuesT into display-ready strings for reporting."""
-
-        def format_seconds(seconds: float) -> str:
-            """Format seconds as HH:MM:SS."""
-            return str(timedelta(seconds=seconds))
-
         return cls(
             total=format_seconds(seconds=time_value.sum),
             name=time_value.name,

--- a/src/pytest_durations/reporting.py
+++ b/src/pytest_durations/reporting.py
@@ -5,21 +5,13 @@ from operator import attrgetter
 from statistics import median
 from typing import NamedTuple
 
-from pytest_durations.types import StrEnum
+from pytest_durations.types import TimeFormat
 
 # Default sort field for report ordering
 _SORT_BY_DEFAULT = "sum"
 _SECONDS_PER_MINUTE = 60
 _SECONDS_PER_HOUR = 3600
 _SECONDS_PER_DAY = 86400
-
-
-class TimeFormat(StrEnum):
-    """Possible duration formatting modes for the report."""
-
-    CLOCK = "clock"
-    SHORT = "short"
-    AUTO = "auto"
 
 
 def format_seconds_clock(seconds: float) -> str:

--- a/src/pytest_durations/types.py
+++ b/src/pytest_durations/types.py
@@ -36,3 +36,11 @@ class GroupBy(StrEnum):
     CLASS = "class"
     FUNCTION = "function"
     NONE = "none"
+
+
+class TimeFormat(StrEnum):
+    """Possible duration formatting modes for the report."""
+
+    CLOCK = "clock"
+    SHORT = "short"
+    AUTO = "auto"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -31,7 +31,7 @@ def fake_config(fake_pluginmanager):
 def test_pytest_addoption(fake_parser, fake_pluginmanager):
     pytest_addoption(fake_parser, fake_pluginmanager)
     assert fake_parser.getgroup.called is True
-    assert fake_parser.getgroup.return_value.addoption.call_count == 4
+    assert fake_parser.getgroup.return_value.addoption.call_count == 5
 
 
 def test_pytest_configure(fake_config, fake_pluginmanager):

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,6 +1,14 @@
 import pytest
 
-from pytest_durations.reporting import ReportRowT, get_report_max_widths, get_report_rows
+from pytest_durations.reporting import (
+    ReportRowT,
+    TimeFormat,
+    format_seconds_clock,
+    format_seconds_short,
+    get_report_max_widths,
+    get_report_rows,
+    resolve_time_format,
+)
 
 
 @pytest.fixture
@@ -53,3 +61,45 @@ def test_get_report_rows_with_rows_limit(sample_measurements, expected_report_ro
 def test_get_report_max_widths(expected_report_rows):
     result = get_report_max_widths(expected_report_rows)
     assert result == (14, 11, 3, 14, 14, 14)
+
+
+def test_time_format_clock():
+    """clock matches the default str(timedelta(...)) output exactly."""
+    assert format_seconds_clock(3.7) == "0:00:03.700000"
+    assert format_seconds_clock(0.0) == "0:00:00"
+
+
+def test_time_format_short():
+    """short uses a compact H:MM:SS with no microseconds, days folded into hours."""
+    assert format_seconds_short(3.7) == "0:00:03"
+    assert format_seconds_short(0.05) == "0:00:00"
+    assert format_seconds_short(90000.0) == "25:00:00"
+    assert format_seconds_short(3723.5) == "1:02:03"
+
+
+def test_resolve_time_format_auto_by_magnitude():
+    """auto picks one form per report based on the global max duration."""
+    assert resolve_time_format(TimeFormat.AUTO, max_seconds=0.5)(0.05) == "50ms"
+    assert resolve_time_format(TimeFormat.AUTO, max_seconds=30.0)(3.7) == "3.700s"
+    assert resolve_time_format(TimeFormat.AUTO, max_seconds=300.0)(185.0) == "3:05"
+    assert resolve_time_format(TimeFormat.AUTO, max_seconds=7200.0)(3723.0) == "1:02:03"
+    assert resolve_time_format(TimeFormat.AUTO, max_seconds=200000.0)(90000.0) == "1d 1:00:00"
+
+
+def test_resolve_time_format_clock_and_short():
+    """clock and short are resolved directly without magnitude selection."""
+    assert resolve_time_format(TimeFormat.CLOCK, max_seconds=100000.0) is format_seconds_clock
+    assert resolve_time_format(TimeFormat.SHORT, max_seconds=100000.0) is format_seconds_short
+
+
+def test_get_report_rows_time_format_short(sample_measurements):
+    """The chosen format threads through every row uniformly."""
+    result = get_report_rows(
+        measurements=sample_measurements,
+        format_seconds=format_seconds_short,
+    )
+    assert result[1:] == [
+        ReportRowT("0:00:03", "fixture2", "3", "0:00:01", "0:00:01", "0:00:01"),
+        ReportRowT("0:00:00", "fixture1", "3", "0:00:00", "0:00:00", "0:00:00"),
+        ReportRowT("0:00:04", "grand total", "6", "0:00:00", "0:00:01", "0:00:00"),
+    ]


### PR DESCRIPTION
## Summary
Adds a `--pytest-durations-time-format` CLI option to control how durations are formatted in reports, addressing #49.

- `clock` (default) — keeps the existing output unchanged (byte-for-byte backward compatible).
- `short` — compact `H:MM:SS`, no microseconds, days folded into hours.
- `auto` — picks one readable form per report by magnitude.

The chosen format is resolved once per report (from the global max duration) and applied uniformly across all four tables.

## Checks
- `pytest`: 104 passed.
- `ruff check .`: passed.
- pre-commit: ruff, check-version, typos all passed.