### PR TITLE
Add --pytest-durations-show to select printed tables (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ pytest-durations:
                         full datetime-style value, "short" a compact H:MM:SS, and
                         "auto" picks one readable form based on the report
                         magnitude. Default: "clock"
+  --pytest-durations-show=SECTIONS
+                        Comma-separated list of report sections to show:
+                        "fixture", "call", "setup", "teardown". Default: show
+                        all sections.
 ```
 
 Note: Please don't confuse these options with the --durations options that come from pytest itself.
@@ -94,6 +98,9 @@ $ pytest
 * Added a `--pytest-durations-time-format` option with `clock`, `auto`, and `short`
   presets for formatting durations in the report (#49). The default (`clock`) keeps the
   existing output unchanged.
+* Added a `--pytest-durations-show` option to select which report sections are printed
+  (`fixture`, `call`, `setup`, `teardown`) (#48). By default all four tables are shown,
+  so existing output is unchanged.
 
 
 ## Change Log

--- a/src/pytest_durations/options.py
+++ b/src/pytest_durations/options.py
@@ -1,7 +1,7 @@
 """Plugin command line arguments parsing module."""
 from typing import TYPE_CHECKING
 
-from pytest_durations.types import GroupBy, TimeFormat
+from pytest_durations.types import ALL_CATEGORIES, GroupBy, TimeFormat, parse_categories
 
 if TYPE_CHECKING:
     from _pytest.config import Config, PytestPluginManager
@@ -12,6 +12,7 @@ DEFAULT_DURATIONS_MIN = 0.005
 DEFAULT_RESULT_LOG = "-"
 DEFAULT_GROUP_BY = GroupBy.FUNCTION
 DEFAULT_TIME_FORMAT = TimeFormat.CLOCK
+DEFAULT_SHOW_SECTIONS = ALL_CATEGORIES
 
 
 def pytest_addoption(parser: "Parser", pluginmanager: "PytestPluginManager") -> None:
@@ -60,6 +61,14 @@ def pytest_addoption(parser: "Parser", pluginmanager: "PytestPluginManager") -> 
              f' "clock" shows the full datetime-style value, "short" a compact H:MM:SS,'
              f' and "auto" picks one readable form based on the report magnitude.'
              f' Default: "{DEFAULT_TIME_FORMAT}"',
+    )
+    group.addoption(
+        "--pytest-durations-show",
+        metavar="SECTIONS",
+        type=parse_categories,
+        default=DEFAULT_SHOW_SECTIONS,
+        help='Comma-separated list of report sections to show: "fixture", "call",'
+             ' "setup", "teardown". Default: show all sections.',
     )
 
 

--- a/src/pytest_durations/plugin.py
+++ b/src/pytest_durations/plugin.py
@@ -131,7 +131,8 @@ class PytestDurationPlugin:
             default=0.0,
         )
         format_seconds = resolve_time_format(time_format=time_format, max_seconds=max_duration)
-        for category in Category:
+        selected_categories = config.getoption("--pytest-durations-show")
+        for category in selected_categories:
             grouping_func = test_grouping_func if category is not Category.FIXTURE_SETUP else fixture_grouping_func
             category_measurements = get_grouped_measurements(
                 grouping_func=grouping_func,

--- a/src/pytest_durations/types.py
+++ b/src/pytest_durations/types.py
@@ -1,4 +1,5 @@
 """Type declarations module."""
+from argparse import ArgumentTypeError
 from collections.abc import Iterator
 from enum import Enum
 
@@ -44,3 +45,32 @@ class TimeFormat(StrEnum):
     CLOCK = "clock"
     SHORT = "short"
     AUTO = "auto"
+
+
+ALL_CATEGORIES: tuple[Category, ...] = tuple(Category)
+
+CATEGORY_NAMES: dict[str, Category] = {
+    "fixture": Category.FIXTURE_SETUP,
+    "call": Category.TEST_CALL,
+    "setup": Category.TEST_SETUP,
+    "teardown": Category.TEST_TEARDOWN,
+}
+
+
+def parse_categories(value: str) -> tuple[Category, ...]:
+    """Parse a comma-separated list of section names into an ordered tuple of categories.
+
+    An empty value selects every category.
+    """
+    if not value:
+        return ALL_CATEGORIES
+    parsed: list[Category] = []
+    for raw_name in value.split(","):
+        name = raw_name.strip()
+        try:
+            parsed.append(CATEGORY_NAMES[name])
+        except KeyError:
+            choices = ", ".join(CATEGORY_NAMES)
+            message = f"unknown section {name!r}; choose from: {choices}"
+            raise ArgumentTypeError(message) from None
+    return tuple(parsed)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,3 +1,4 @@
+import argparse
 import importlib
 import sys
 from unittest.mock import create_autospec
@@ -5,6 +6,7 @@ from unittest.mock import create_autospec
 import pytest
 
 from pytest_durations.options import pytest_addoption, pytest_configure
+from pytest_durations.types import ALL_CATEGORIES, Category, parse_categories
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -31,7 +33,26 @@ def fake_config(fake_pluginmanager):
 def test_pytest_addoption(fake_parser, fake_pluginmanager):
     pytest_addoption(fake_parser, fake_pluginmanager)
     assert fake_parser.getgroup.called is True
-    assert fake_parser.getgroup.return_value.addoption.call_count == 5
+    assert fake_parser.getgroup.return_value.addoption.call_count == 6
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("", ALL_CATEGORIES),
+        ("fixture", (Category.FIXTURE_SETUP,)),
+        ("fixture,call", (Category.FIXTURE_SETUP, Category.TEST_CALL)),
+        ("fixture, call", (Category.FIXTURE_SETUP, Category.TEST_CALL)),
+        ("teardown,setup", (Category.TEST_TEARDOWN, Category.TEST_SETUP)),
+    ],
+)
+def test_parse_categories(value: str, expected: tuple[Category, ...]) -> None:
+    assert parse_categories(value) == expected
+
+
+def test_parse_categories_unknown() -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_categories("bogus")
 
 
 def test_pytest_configure(fake_config, fake_pluginmanager):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -100,6 +100,30 @@ def test_plugin_disable(pytester, sample_testfile):
     result.stdout.no_fnmatch_line("*duration top*")
 
 
+@pytest.mark.parametrize(
+    ("show", "expected", "absent"),
+    [
+        (
+            "call",
+            ["* test call duration top *"],
+            ["* fixture duration top *", "* test setup duration top *", "* test teardown duration top *"],
+        ),
+        (
+            "fixture,call",
+            ["* fixture duration top *", "* test call duration top *"],
+            ["* test setup duration top *", "* test teardown duration top *"],
+        ),
+    ],
+)
+def test_plugin_show_sections(pytester, sample_testfile, show, expected, absent):
+    """Only the requested report sections are emitted."""
+    result = pytester.runpytest("--pytest-durations-show", show)
+    result.assert_outcomes(passed=2)
+    result.stdout.fnmatch_lines(expected)
+    for line in absent:
+        result.stdout.no_fnmatch_line(line)
+
+
 def test_plugin_xdist_disabled(pytester, sample_testfile):
     """Run when pytest-xdist is absent or disabled should be successful (#3)."""
     result = pytester.runpytest("-p", "no:xdist")


### PR DESCRIPTION
Closes #48

## Summary

Adds a `--pytest-durations-show` option that lets the user choose which report
sections/tables are printed. By default (option absent or empty) all four tables are
shown, so existing output is unchanged.

CLI short names map to report categories:
- `fixture` -> fixture setup
- `call` -> test call
- `setup` -> test setup
- `teardown` -> test teardown

Unknown section names produce a clean argparse error instead of being silently ignored.

## Behavior

- `--pytest-durations-show=call` prints only the "test call duration top" table.
- `--pytest-durations-show=fixture,call` prints the two selected tables, with column
  widths aligned to the shown tables only (widths are computed inside the loop).
- Invalid names (e.g. `=bogus`) error out via argparse.
- `--pytest-durations-time-format=auto` still computes `max_duration` over all
  measurements, so the auto form stays stable regardless of section filtering.

## Implementation notes

The parsing/mapping helpers live in `types.py` (which is excluded from coverage) to avoid
the early `reporting` import coverage bug from #52. Section-name to `Category` mapping:
`CATEGORY_NAMES` + `parse_categories`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Pre-flight Checklist

- [x] Tests pass and coverage stays at 100% (`pytest --cov`)
- [x] `ruff` and `typos` pass
- [x] README documents the new option and an Unreleased change-log entry
