### PR TITLE
Add --pytest-durations-columns to select report columns (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ pytest-durations:
                         Comma-separated list of report sections to show:
                         "fixture", "call", "setup", "teardown". Default: show
                         all sections.
+  --pytest-durations-columns=COLUMNS
+                        Comma-separated list of stat columns to show: "total",
+                        "num", "min", "med", "max". The test/fixture name is
+                        always shown second, and the first listed column is used
+                        to sort the report. Default: total,num,med,max.
 ```
 
 Note: Please don't confuse these options with the --durations options that come from pytest itself.
@@ -95,6 +100,10 @@ $ pytest
 
 ## Unreleased
 
+* Added a `--pytest-durations-columns` option to select which stat columns are
+  printed (`total`, `num`, `min`, `med`, `max`) and which one sorts the report
+  (#47). The test/fixture name is always shown second. The default matches the
+  existing output, so nothing changes unless the flag is used.
 * Added a `--pytest-durations-time-format` option with `clock`, `auto`, and `short`
   presets for formatting durations in the report (#49). The default (`clock`) keeps the
   existing output unchanged.

--- a/src/pytest_durations/options.py
+++ b/src/pytest_durations/options.py
@@ -1,7 +1,14 @@
 """Plugin command line arguments parsing module."""
 from typing import TYPE_CHECKING
 
-from pytest_durations.types import ALL_CATEGORIES, GroupBy, TimeFormat, parse_categories
+from pytest_durations.types import (
+    ALL_CATEGORIES,
+    DEFAULT_COLUMNS,
+    GroupBy,
+    TimeFormat,
+    parse_categories,
+    parse_columns,
+)
 
 if TYPE_CHECKING:
     from _pytest.config import Config, PytestPluginManager
@@ -69,6 +76,16 @@ def pytest_addoption(parser: "Parser", pluginmanager: "PytestPluginManager") -> 
         default=DEFAULT_SHOW_SECTIONS,
         help='Comma-separated list of report sections to show: "fixture", "call",'
              ' "setup", "teardown". Default: show all sections.',
+    )
+    group.addoption(
+        "--pytest-durations-columns",
+        metavar="COLUMNS",
+        type=parse_columns,
+        default=DEFAULT_COLUMNS,
+        help='Comma-separated list of stat columns to show: "total", "num", "min",'
+             ' "med", "max". The test/fixture name is always shown second, and the'
+             ' first listed column is used to sort the report.'
+             f' Default: {",".join(DEFAULT_COLUMNS)}.',
     )
 
 

--- a/src/pytest_durations/plugin.py
+++ b/src/pytest_durations/plugin.py
@@ -17,9 +17,14 @@ from pytest_durations.helpers import (
 )
 from pytest_durations.measure import MeasureDuration
 from pytest_durations.options import DEFAULT_RESULT_LOG
-from pytest_durations.reporting import get_report_max_widths, get_report_rows, resolve_time_format
+from pytest_durations.reporting import (
+    get_report_rows,
+    get_selected_max_widths,
+    report_column_fields,
+    resolve_time_format,
+)
 from pytest_durations.ticker import get_current_ticks
-from pytest_durations.types import Category
+from pytest_durations.types import COLUMN_SORT_FIELDS, Category
 
 if TYPE_CHECKING:
     from _pytest.config import Config, ExitCode
@@ -116,11 +121,12 @@ class PytestDurationPlugin:
         durations = config.getoption("--pytest-durations")
         durations_min = config.getoption("--pytest-durations-min")
         reports = []
-        widths = [0] * 5
         group_by = config.getoption("--pytest-durations-group-by")
         time_format = config.getoption("--pytest-durations-time-format")
         test_grouping_func = get_test_grouping_func(group_by=group_by)
         fixture_grouping_func = get_fixture_grouping_func(group_by=group_by)
+        selected_columns = config.getoption("--pytest-durations-columns")
+        sort_by = COLUMN_SORT_FIELDS[selected_columns[0]]
         max_duration = max(
             (
                 max(times)
@@ -142,17 +148,21 @@ class PytestDurationPlugin:
                 measurements=category_measurements,
                 duration_min=durations_min,
                 max_rows=durations,
+                sort_by=sort_by,
                 format_seconds=format_seconds,
             )
             reports.append((f"{category} duration top", category_report_rows))
-            widths = [max(*a) for a in zip(widths, get_report_max_widths(category_report_rows), strict=False)]
+        rendered_columns = report_column_fields(selected_columns)
+        all_rows = [row for _, rows in reports for row in rows]
+        widths = get_selected_max_widths(all_rows, selected_columns)
         fullwidth = max(fullwidth, sum(widths) + len(widths) - 1)
         for section_name, category_report_rows in reports:
             terminalreporter.write_sep(sep="=", title=section_name, fullwidth=fullwidth)
             for idx, row in enumerate(category_report_rows):
+                # align columns right except test name column
                 content = " ".join(
-                    f"{col:{'>' if idx and c else '<'}{width}}"  # align columns right except test name column
-                    for col, width, c in zip(row, widths, count(-1))
+                    f"{getattr(row, col):{'>' if idx and c else '<'}{width}}"
+                    for col, width, c in zip(rendered_columns, widths, count(-1))
                 )
                 terminalreporter.line(content)
 

--- a/src/pytest_durations/plugin.py
+++ b/src/pytest_durations/plugin.py
@@ -24,7 +24,7 @@ from pytest_durations.reporting import (
     resolve_time_format,
 )
 from pytest_durations.ticker import get_current_ticks
-from pytest_durations.types import COLUMN_SORT_FIELDS, Category
+from pytest_durations.types import COLUMN_NAMES, Category
 
 if TYPE_CHECKING:
     from _pytest.config import Config, ExitCode
@@ -126,7 +126,7 @@ class PytestDurationPlugin:
         test_grouping_func = get_test_grouping_func(group_by=group_by)
         fixture_grouping_func = get_fixture_grouping_func(group_by=group_by)
         selected_columns = config.getoption("--pytest-durations-columns")
-        sort_by = COLUMN_SORT_FIELDS[selected_columns[0]]
+        sort_by = COLUMN_NAMES[selected_columns[0]]
         max_duration = max(
             (
                 max(times)

--- a/src/pytest_durations/reporting.py
+++ b/src/pytest_durations/reporting.py
@@ -144,6 +144,26 @@ def get_report_max_widths(report_rows: Collection["ReportRowT"]) -> tuple[int, .
     )
 
 
+def report_column_fields(selected_columns: Collection[str]) -> tuple[str, ...]:
+    """Resolve selected stat columns into the display fields actually rendered.
+
+    The first selected column is rendered first (it is the report sort key), then
+    ``name``, then the remaining selected columns. ``name`` is therefore always the
+    second rendered column and can never be first.
+    """
+    ordered = tuple(selected_columns)
+    return (ordered[0], "name", *ordered[1:])
+
+
+def get_selected_max_widths(
+    report_rows: Collection["ReportRowT"],
+    selected_columns: Collection[str],
+) -> tuple[int, ...]:
+    """Return the maximum width for each actually-rendered column."""
+    fields = report_column_fields(selected_columns)
+    return tuple(max(len(getattr(row, field)) for row in report_rows) for field in fields)
+
+
 class TimeValuesT(NamedTuple):
     """Aggregated timing statistics for a single operation."""
 

--- a/src/pytest_durations/types.py
+++ b/src/pytest_durations/types.py
@@ -49,6 +49,27 @@ class TimeFormat(StrEnum):
 
 ALL_CATEGORIES: tuple[Category, ...] = tuple(Category)
 
+# Selectable stat columns for --pytest-durations-columns. The row key ("name") is
+# always shown separately and can never be selected or used as a sort field.
+COLUMN_NAMES: dict[str, str] = {
+    "total": "total",
+    "num": "num",
+    "min": "min",
+    "med": "med",
+    "max": "max",
+}
+
+# Map a selectable column name to the numeric TimeValuesT field used for sorting.
+COLUMN_SORT_FIELDS: dict[str, str] = {
+    "total": "sum",
+    "num": "calls",
+    "min": "min",
+    "med": "med",
+    "max": "max",
+}
+
+DEFAULT_COLUMNS: tuple[str, ...] = ("total", "num", "med", "max")
+
 CATEGORY_NAMES: dict[str, Category] = {
     "fixture": Category.FIXTURE_SETUP,
     "call": Category.TEST_CALL,
@@ -73,4 +94,22 @@ def parse_categories(value: str) -> tuple[Category, ...]:
             choices = ", ".join(CATEGORY_NAMES)
             message = f"unknown section {name!r}; choose from: {choices}"
             raise ArgumentTypeError(message) from None
+    return tuple(parsed)
+
+
+def parse_columns(value: str) -> tuple[str, ...]:
+    """Parse a comma-separated list of stat column names into an ordered tuple.
+
+    An empty value selects the default column set.
+    """
+    if not value:
+        return DEFAULT_COLUMNS
+    parsed: list[str] = []
+    for raw_name in value.split(","):
+        name = raw_name.strip()
+        if name not in COLUMN_NAMES:
+            choices = ", ".join(COLUMN_NAMES)
+            message = f"unknown column {name!r}; choose from: {choices}"
+            raise ArgumentTypeError(message)
+        parsed.append(name)
     return tuple(parsed)

--- a/src/pytest_durations/types.py
+++ b/src/pytest_durations/types.py
@@ -49,23 +49,16 @@ class TimeFormat(StrEnum):
 
 ALL_CATEGORIES: tuple[Category, ...] = tuple(Category)
 
-# Selectable stat columns for --pytest-durations-columns. The row key ("name") is
-# always shown separately and can never be selected or used as a sort field.
+# Selectable stat columns for --pytest-durations-columns. Each key is a selectable
+# column name (also a ReportRowT field); its value is the TimeValuesT field used for
+# sorting. The row key ("name") is always shown separately and can never be selected
+# or used as a sort field.
 COLUMN_NAMES: dict[str, str] = {
-    "total": "total",
-    "num": "num",
-    "min": "min",
-    "med": "med",
-    "max": "max",
-}
-
-# Map a selectable column name to the numeric TimeValuesT field used for sorting.
-COLUMN_SORT_FIELDS: dict[str, str] = {
-    "total": "sum",
     "num": "calls",
     "min": "min",
-    "med": "med",
     "max": "max",
+    "med": "med",
+    "total": "sum",
 }
 
 DEFAULT_COLUMNS: tuple[str, ...] = ("total", "num", "med", "max")

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -6,7 +6,13 @@ from unittest.mock import create_autospec
 import pytest
 
 from pytest_durations.options import pytest_addoption, pytest_configure
-from pytest_durations.types import ALL_CATEGORIES, Category, parse_categories
+from pytest_durations.types import (
+    ALL_CATEGORIES,
+    DEFAULT_COLUMNS,
+    Category,
+    parse_categories,
+    parse_columns,
+)
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -33,7 +39,7 @@ def fake_config(fake_pluginmanager):
 def test_pytest_addoption(fake_parser, fake_pluginmanager):
     pytest_addoption(fake_parser, fake_pluginmanager)
     assert fake_parser.getgroup.called is True
-    assert fake_parser.getgroup.return_value.addoption.call_count == 6
+    assert fake_parser.getgroup.return_value.addoption.call_count == 7
 
 
 @pytest.mark.parametrize(
@@ -53,6 +59,25 @@ def test_parse_categories(value: str, expected: tuple[Category, ...]) -> None:
 def test_parse_categories_unknown() -> None:
     with pytest.raises(argparse.ArgumentTypeError):
         parse_categories("bogus")
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("", DEFAULT_COLUMNS),
+        ("total", ("total",)),
+        ("max,min", ("max", "min")),
+        ("num, med", ("num", "med")),
+        ("med,min,max", ("med", "min", "max")),
+    ],
+)
+def test_parse_columns(value: str, expected: tuple[str, ...]) -> None:
+    assert parse_columns(value) == expected
+
+
+def test_parse_columns_unknown() -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        parse_columns("name")
 
 
 def test_pytest_configure(fake_config, fake_pluginmanager):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -124,6 +124,36 @@ def test_plugin_show_sections(pytester, sample_testfile, show, expected, absent)
         result.stdout.no_fnmatch_line(line)
 
 
+@pytest.mark.parametrize(
+    ("columns", "expected_header"),
+    [
+        ("min,med,max", "*min*name*med*max*"),
+        ("max", "*max*name*"),
+        ("num,min,med,max", "*num*name*min*med*max*"),
+    ],
+)
+def test_plugin_columns_order(pytester, sample_testfile, columns, expected_header):
+    """name is always the second rendered column; the first selected leads."""
+    result = pytester.runpytest("--pytest-durations-columns", columns)
+    result.assert_outcomes(passed=2)
+    result.stdout.fnmatch_lines([expected_header])
+
+
+def test_plugin_columns_include_min(pytester, sample_testfile):
+    """min, excluded from the default, is available via the flag."""
+    result = pytester.runpytest("--pytest-durations-columns", "min,med,max")
+    result.assert_outcomes(passed=2)
+    result.stdout.fnmatch_lines(["*min*name*med*max*"])
+
+
+def test_plugin_columns_default_unchanged(pytester, sample_testfile, expected_output_lines):
+    """Without the flag, the default columns (no min) keep current output."""
+    result = pytester.runpytest()
+    result.assert_outcomes(passed=2)
+    result.stdout.fnmatch_lines(expected_output_lines)
+    result.stdout.fnmatch_lines(["*total*name*num*med*max*"])
+
+
 def test_plugin_xdist_disabled(pytester, sample_testfile):
     """Run when pytest-xdist is absent or disabled should be successful (#3)."""
     result = pytester.runpytest("-p", "no:xdist")

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -7,6 +7,8 @@ from pytest_durations.reporting import (
     format_seconds_short,
     get_report_max_widths,
     get_report_rows,
+    get_selected_max_widths,
+    report_column_fields,
     resolve_time_format,
 )
 
@@ -61,6 +63,33 @@ def test_get_report_rows_with_rows_limit(sample_measurements, expected_report_ro
 def test_get_report_max_widths(expected_report_rows):
     result = get_report_max_widths(expected_report_rows)
     assert result == (14, 11, 3, 14, 14, 14)
+
+
+@pytest.mark.parametrize(
+    ("selected", "expected"),
+    [
+        (("total", "num", "med", "max"), ("total", "name", "num", "med", "max")),
+        (("max",), ("max", "name")),
+        (("min", "max"), ("min", "name", "max")),
+        (("med", "min", "max"), ("med", "name", "min", "max")),
+    ],
+)
+def test_report_column_fields(selected, expected):
+    """name is always the second rendered column; first selected leads."""
+    assert report_column_fields(selected) == expected
+
+
+@pytest.mark.parametrize(
+    ("selected", "expected"),
+    [
+        (("total", "num", "med", "max"), (14, 11, 3, 14, 14)),
+        (("max",), (14, 11)),
+        (("min", "max"), (14, 11, 14)),
+    ],
+)
+def test_get_selected_max_widths(expected_report_rows, selected, expected):
+    """Widths are computed only over the actually-rendered columns."""
+    assert get_selected_max_widths(expected_report_rows, selected) == expected
 
 
 def test_time_format_clock():


### PR DESCRIPTION
## Summary

Adds a `--pytest-durations-columns` option that lets the user choose which stat columns are printed and which one sorts the report. The test/fixture name is always shown second. This completes the #47 feature request (the core "show max instead of min" was already fixed in PR #50; the selectable-columns enhancement is finished here).

- New option `--pytest-durations-columns=total,num,min,med,max`, default `total,num,med,max` (matches current output — `min` is available via the flag for backward compatibility).
- The first listed column is the sort key (`total→sum`, `num→calls`, `min→min`, `med→med`, `max→max`); `name` can never be the sort key.
- Removes the fragile `widths = [0] * 5` / `zip(..., strict=False)` truncation hack in `plugin.py`; widths are now computed only over the actually-rendered columns.
- Default output is preserved byte-for-byte.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Code style / cleanup

## Test Procedure

- `pytest` — 130 passed, 100% coverage (`fail_under = 100`, branch coverage on).
- `ruff check` and `typos` clean; `check-version` passes.
- Manual checks:
  - Default output identical to before.
  - `--pytest-durations-columns=min,max` and `=min,med,max` render correct headers/columns with `name` second, right-aligned, correct widths.

Closes #47
