### PR TITLE
Release 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ $ pytest
 
 ## Unreleased
 
+## Change Log
+
+### 1.8.0 (Aug 07, 2026)
+
 * Added a `--pytest-durations-columns` option to select which stat columns are
   printed (`total`, `num`, `min`, `med`, `max`) and which one sorts the report
   (#47). The test/fixture name is always shown second. The default matches the
@@ -110,9 +114,6 @@ $ pytest
 * Added a `--pytest-durations-show` option to select which report sections are printed
   (`fixture`, `call`, `setup`, `teardown`) (#48). By default all four tables are shown,
   so existing output is unchanged.
-
-
-## Change Log
 
 ### 1.7.1 (Aug 06, 2026)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-durations"
-version = "1.7.1"
+version = "1.8.0"
 description = "Pytest plugin reporting fixtures and test functions execution time."
 authors = ["Oleg Blednov <oleg.codev@gmail.com>"]
 license = "MIT"

--- a/src/pytest_durations/__init__.py
+++ b/src/pytest_durations/__init__.py
@@ -2,4 +2,4 @@
 
 from pytest_durations.options import pytest_addoption, pytest_configure  # noqa: F401
 
-__version__ = "1.7.1"
+__version__ = "1.8.0"


### PR DESCRIPTION
Bump version to 1.8.0.

This release adds three new user-facing options:
- `--pytest-durations-columns` to select which stat columns are shown and which one sorts the report.
- `--pytest-durations-time-format` with `clock`, `auto`, and `short` presets.
- `--pytest-durations-show` to select which report sections are printed.
