### PR TITLE
ci: switch PyPI publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -63,6 +63,4 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         if: github.event.release.prerelease == false
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+        # Trusted Publishing via OIDC — no token required


### PR DESCRIPTION
Remove explicit API token for PyPI production uploads. Trusted Publisher is already configured on PyPI for this repo. TestPyPI token is kept as-is.