### PR TITLE
ci: add id-token permission for Trusted Publishing on main

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -47,6 +47,8 @@ jobs:
     needs: [ ci ]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for Trusted Publishing to PyPI via OIDC
     steps:
       - name: Download artefacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
The cd job needs id-token: write for PyPI Trusted Publishing (OIDC). This was already fixed on release/1.6.x; applying to main as well.