### PR TITLE
refactor(types): replace Category metaclass with StrEnum

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ $ pytest
 
 ## Unreleased
 
+* Refactored Category to use StrEnum for improved type safety and cleaner serialization (#59).
+
 ## Change Log
 
 ### 1.8.0 (Aug 07, 2026)

--- a/src/pytest_durations/types.py
+++ b/src/pytest_durations/types.py
@@ -1,24 +1,6 @@
 """Type declarations module."""
 from argparse import ArgumentTypeError
-from collections.abc import Iterator
 from enum import Enum
-
-
-class CategoryMeta(type):
-    """Category should be a plain string, but compatible with Enum class iterator."""
-
-    def __iter__(cls) -> Iterator[str]:
-        """Return enumeration of class field values."""
-        return (v for k, v in cls.__dict__.items() if not k.startswith("__"))
-
-
-class Category(metaclass=CategoryMeta):
-    """Measurement category constants."""
-
-    FIXTURE_SETUP = "fixture"
-    TEST_CALL = "test call"
-    TEST_SETUP = "test setup"
-    TEST_TEARDOWN = "test teardown"
 
 
 class StrEnum(str, Enum):
@@ -27,6 +9,15 @@ class StrEnum(str, Enum):
     def __str__(self) -> str:
         """Return the current value (expected to be a string)."""
         return self.value
+
+
+class Category(StrEnum):
+    """Measurement category constants."""
+
+    FIXTURE_SETUP = "fixture"
+    TEST_CALL = "test call"
+    TEST_SETUP = "test setup"
+    TEST_TEARDOWN = "test teardown"
 
 
 class GroupBy(StrEnum):


### PR DESCRIPTION
Fixes #59

- Remove CategoryMeta custom metaclass; Category now inherits from StrEnum
- Consistent with GroupBy and TimeFormat patterns
- Zero breaking changes: xdist serialization, plugin logic, and all tests pass unchanged
- Better IDE autocomplete, type checker support, and refactoring safety