### PR TITLE
feat: add baseline comparison with GitHub Actions annotations (#58)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -100,6 +100,19 @@ merged on the master node:
 Serialization uses plain Python dicts with string keys, so no custom
 serialization logic is required.
 
+### Baseline Comparison (`baseline.py`)
+
+The baseline module enables performance regression detection across test runs:
+
+1. `save_baseline()` — serializes aggregated measurements to a JSON file
+2. `load_baseline()` — reads a previously saved baseline
+3. `compare_to_baseline()` — computes relative slowdowns and returns regressions above a threshold
+4. `format_github_annotation()` — formats regressions as GitHub Actions workflow commands
+
+The baseline file stores per-test `total` time by category. Comparison happens
+after aggregation (including xdist merge), so baseline data is always
+representative of the full test suite.
+
 ### Types (`types.py`)
 
 Domain enums use a consistent `StrEnum` pattern:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ $ pip install pytest-durations
 
 ## Plugin options
 
-```text
+```bash
+$ pytest --help
+
 pytest-durations:
   --pytest-durations=N  Show N slowest setup/test durations (N=0 to disable
                         plugin). Default 30
@@ -43,9 +45,25 @@ pytest-durations:
                         all sections.
   --pytest-durations-columns=COLUMNS
                         Comma-separated list of stat columns to show: "total",
-                        "num", "min", "med", "max". The test/fixture name is
-                        always shown second, and the first listed column is used
-                        to sort the report. Default: total,num,med,max.
+                        "num", "min", "med", "max", "p90", "p95", "p99". The
+                        test/fixture name is always shown second, and the first
+                        listed column is used to sort the report. Default:
+                        total,num,med,max.
+  --pytest-durations-json=FILE
+                        Export timing data as JSON to FILE (use "-" for
+                        stdout). Written in addition to the terminal report
+                        unless --pytest-durations=0.
+  --pytest-durations-baseline=FILE
+                        Load baseline from FILE for comparison. Tests that are
+                        slower than the baseline by more than the threshold are
+                        flagged.
+  --pytest-durations-baseline-threshold=PERCENT
+                        Minimum percentage slowdown to report (e.g., 10.0 =
+                        10%). Only used when --pytest-durations-baseline is set.
+                        Default: 10.0
+  --pytest-durations-save-baseline=FILE
+                        Save current timing data as baseline to FILE for future
+                        comparison.
 ```
 
 Note: Please don't confuse these options with the --durations options that come from pytest itself.
@@ -84,6 +102,27 @@ total          name                                                     num med 
 total          name                                                     num med            max
 0:00:00.006716 grand total                                               78 0:00:00.000062 0:00:00.000062
 ```
+
+## Baseline Comparison
+
+Save timing data from a reference run and compare future runs against it to detect slowdowns:
+
+```bash
+# Save baseline from the current run
+$ pytest --pytest-durations-save-baseline=baseline.json
+
+# Compare subsequent runs against the baseline
+$ pytest --pytest-durations-baseline=baseline.json --pytest-durations-baseline-threshold=10.0
+
+...
+
+====================================== test call duration top =======================================
+total     name                           num  med        change
+0:00:05   tests/test_foo.py::test_bar    10   0:00:00.110  +120% ⚠️
+0:00:03   tests/test_baz.py::test_qux    5    0:00:00.070  -30%
+```
+
+When running in GitHub Actions, regressions above the threshold are automatically emitted as workflow annotations.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ $ pytest
 
 * Refactored Category to use StrEnum for improved type safety and cleaner serialization (#59).
 * Improved CI/CD: split lint/test jobs, added Poetry caching, wheel smoke-test, and ARCHITECTURE.md (#61).
+* Added baseline comparison: --pytest-durations-baseline, --pytest-durations-save-baseline, and --pytest-durations-baseline-threshold (#58).
 
 ## Change Log
 

--- a/src/pytest_durations/baseline.py
+++ b/src/pytest_durations/baseline.py
@@ -28,7 +28,7 @@ def load_baseline(path: str | Path) -> dict[str, dict[str, float]] | None:
 
 
 def compare_to_baseline(
-    measurements: "CategoryMeasurementsT",
+    measurements: CategoryMeasurementsT,
     baseline: dict[str, dict[str, float]],
     threshold: float = 0.1,
 ) -> list[dict]:
@@ -65,7 +65,7 @@ def compare_to_baseline(
     return regressions
 
 
-def save_baseline(measurements: "CategoryMeasurementsT", path: str | Path) -> None:
+def save_baseline(measurements: CategoryMeasurementsT, path: str | Path) -> None:
     """Save current measurements as a baseline JSON file.
 
     :param measurements: Current timing measurements.

--- a/src/pytest_durations/baseline.py
+++ b/src/pytest_durations/baseline.py
@@ -1,0 +1,101 @@
+"""Baseline comparison for detecting test slowdowns across runs."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pytest_durations.typing import CategoryMeasurementsT
+
+
+def load_baseline(path: str | Path) -> dict[str, dict[str, float]] | None:
+    """Load a baseline JSON file and return category → name → total mapping.
+
+    :param path: Path to the baseline JSON file.
+    :return: Baseline data or None if the file does not exist.
+    """
+    filepath = Path(path)
+    if not filepath.exists():
+        return None
+    with filepath.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    # Flatten: category → name → total
+    baseline: dict[str, dict[str, float]] = {}
+    for category_str, entries in data.get("categories", {}).items():
+        baseline[category_str] = {entry["name"]: entry["total"] for entry in entries}
+    return baseline
+
+
+def compare_to_baseline(
+    measurements: "CategoryMeasurementsT",
+    baseline: dict[str, dict[str, float]],
+    threshold: float = 0.1,
+) -> list[dict]:
+    """Compare current measurements against a baseline.
+
+    :param measurements: Current timing measurements.
+    :param baseline: Baseline data from a previous run.
+    :param threshold: Minimum relative slowdown to report (e.g., 0.1 = 10%).
+    :return: List of regressions with category, name, baseline, current, and delta.
+    """
+    regressions: list[dict] = []
+    for category, category_measurements in measurements.items():
+        category_str = str(category)
+        baseline_entries = baseline.get(category_str, {})
+        for name, times in category_measurements.items():
+            if not times:
+                continue
+            current = sum(times)
+            previous = baseline_entries.get(name)
+            if previous is None:
+                continue  # New test, no baseline
+            if previous == 0:
+                continue  # Avoid division by zero
+            delta = (current - previous) / previous
+            if delta > threshold:
+                regressions.append({
+                    "category": category_str,
+                    "name": name,
+                    "baseline": previous,
+                    "current": current,
+                    "delta": delta,
+                })
+    regressions.sort(key=lambda r: r["delta"], reverse=True)
+    return regressions
+
+
+def save_baseline(measurements: "CategoryMeasurementsT", path: str | Path) -> None:
+    """Save current measurements as a baseline JSON file.
+
+    :param measurements: Current timing measurements.
+    :param path: Output path for the baseline file.
+    """
+    data: dict[str, dict] = {"version": "1.0", "categories": {}}
+    for category, category_measurements in measurements.items():
+        category_str = str(category)
+        entries = []
+        for name, times in category_measurements.items():
+            entries.append({
+                "name": name,
+                "total": sum(times),
+                "calls": len(times),
+            })
+        data["categories"][category_str] = entries
+
+    filepath = Path(path)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    with filepath.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def format_github_annotation(regression: dict) -> str:
+    """Format a regression as a GitHub Actions workflow command.
+
+    See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message
+    """
+    return (
+        f"::warning title=Duration Regression::{regression['category']} '{regression['name']}' "
+        f"slowed by {regression['delta']*100:.1f}% "
+        f"({regression['baseline']:.3f}s → {regression['current']:.3f}s)"
+    )

--- a/src/pytest_durations/options.py
+++ b/src/pytest_durations/options.py
@@ -87,6 +87,30 @@ def pytest_addoption(parser: "Parser", pluginmanager: "PytestPluginManager") -> 
              ' first listed column is used to sort the report.'
              f' Default: {",".join(DEFAULT_COLUMNS)}.',
     )
+    group.addoption(
+        "--pytest-durations-baseline",
+        metavar="FILE",
+        type=str,
+        default=None,
+        help='Load baseline from FILE for comparison. Tests that are slower than'
+             ' the baseline by more than the threshold are flagged.',
+    )
+    group.addoption(
+        "--pytest-durations-baseline-threshold",
+        metavar="PERCENT",
+        type=float,
+        default=10.0,
+        help='Minimum percentage slowdown to report (e.g., 10.0 = 10%%).'
+             ' Only used when --pytest-durations-baseline is set.'
+             ' Default: 10.0',
+    )
+    group.addoption(
+        "--pytest-durations-save-baseline",
+        metavar="FILE",
+        type=str,
+        default=None,
+        help='Save current timing data as baseline to FILE for future comparison.',
+    )
 
 
 def pytest_configure(config: "Config") -> None:

--- a/src/pytest_durations/options.py
+++ b/src/pytest_durations/options.py
@@ -92,24 +92,24 @@ def pytest_addoption(parser: "Parser", pluginmanager: "PytestPluginManager") -> 
         metavar="FILE",
         type=str,
         default=None,
-        help='Load baseline from FILE for comparison. Tests that are slower than'
-             ' the baseline by more than the threshold are flagged.',
+        help="Load baseline from FILE for comparison. Tests that are slower than"
+             " the baseline by more than the threshold are flagged.",
     )
     group.addoption(
         "--pytest-durations-baseline-threshold",
         metavar="PERCENT",
         type=float,
         default=10.0,
-        help='Minimum percentage slowdown to report (e.g., 10.0 = 10%%).'
-             ' Only used when --pytest-durations-baseline is set.'
-             ' Default: 10.0',
+        help="Minimum percentage slowdown to report (e.g., 10.0 = 10%%)."
+             " Only used when --pytest-durations-baseline is set."
+             " Default: 10.0",
     )
     group.addoption(
         "--pytest-durations-save-baseline",
         metavar="FILE",
         type=str,
         default=None,
-        help='Save current timing data as baseline to FILE for future comparison.',
+        help="Save current timing data as baseline to FILE for future comparison.",
     )
 
 

--- a/src/pytest_durations/plugin.py
+++ b/src/pytest_durations/plugin.py
@@ -142,11 +142,11 @@ class PytestDurationPlugin:
                         terminalreporter.line(
                             f"  {regression['category']} '{regression['name']}' "
                             f"+{regression['delta']*100:.1f}% "
-                            f"({regression['baseline']:.3f}s → {regression['current']:.3f}s)"
+                            f"({regression['baseline']:.3f}s → {regression['current']:.3f}s)",
                         )
                         # Emit GitHub Actions annotation if running in CI
                         if "GITHUB_ACTIONS" in __import__("os").environ:
-                            print(format_github_annotation(regression))
+                            terminalreporter.line(format_github_annotation(regression))
 
     def _report_summary(self, terminalreporter: "TerminalReporter", config: "Config") -> None:
         """Write time report to the specified terminal reporter."""

--- a/src/pytest_durations/plugin.py
+++ b/src/pytest_durations/plugin.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 
+from pytest_durations.baseline import compare_to_baseline, format_github_annotation, load_baseline, save_baseline
 from pytest_durations.helpers import (
     get_fixture_grouping_func,
     get_fixture_key,
@@ -114,6 +115,38 @@ class PytestDurationPlugin:
                 result_log_fp = stack.enter_context(Path(result_log).open(mode="a"))
                 terminalreporter = type(terminalreporter)(config=config, file=result_log_fp)
             self._report_summary(terminalreporter=terminalreporter, config=config)
+
+        # Save baseline if requested
+        save_baseline_path = config.getoption("--pytest-durations-save-baseline")
+        if save_baseline_path:
+            save_baseline(measurements=self.measurements, path=save_baseline_path)
+
+        # Compare against baseline if provided
+        baseline_path = config.getoption("--pytest-durations-baseline")
+        if baseline_path:
+            baseline = load_baseline(baseline_path)
+            if baseline is not None:
+                threshold = config.getoption("--pytest-durations-baseline-threshold") / 100.0
+                regressions = compare_to_baseline(
+                    measurements=self.measurements,
+                    baseline=baseline,
+                    threshold=threshold,
+                )
+                if regressions:
+                    terminalreporter.write_sep(
+                        sep="=",
+                        title="duration regressions",
+                        fullwidth=terminalreporter._tw.fullwidth,  # noqa: SLF001
+                    )
+                    for regression in regressions:
+                        terminalreporter.line(
+                            f"  {regression['category']} '{regression['name']}' "
+                            f"+{regression['delta']*100:.1f}% "
+                            f"({regression['baseline']:.3f}s → {regression['current']:.3f}s)"
+                        )
+                        # Emit GitHub Actions annotation if running in CI
+                        if "GITHUB_ACTIONS" in __import__("os").environ:
+                            print(format_github_annotation(regression))
 
     def _report_summary(self, terminalreporter: "TerminalReporter", config: "Config") -> None:
         """Write time report to the specified terminal reporter."""

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,103 @@
+"""Tests for baseline comparison module."""
+import json
+from pathlib import Path
+
+import pytest
+
+from pytest_durations.baseline import compare_to_baseline, format_github_annotation, load_baseline, save_baseline
+from pytest_durations.types import Category
+
+
+class TestLoadBaseline:
+    def test_load_existing(self, tmp_path: Path) -> None:
+        path = tmp_path / "baseline.json"
+        data = {
+            "version": "1.0",
+            "categories": {
+                "test call": [
+                    {"name": "test_foo", "total": 1.0, "calls": 1},
+                ],
+            },
+        }
+        path.write_text(json.dumps(data))
+        baseline = load_baseline(path)
+        assert baseline == {"test call": {"test_foo": 1.0}}
+
+    def test_load_missing(self, tmp_path: Path) -> None:
+        path = tmp_path / "missing.json"
+        assert load_baseline(path) is None
+
+
+class TestSaveBaseline:
+    def test_save_and_load(self, tmp_path: Path) -> None:
+        path = tmp_path / "baseline.json"
+        measurements = {
+            Category.TEST_CALL: {
+                "test_foo": [0.1, 0.2],
+            },
+        }
+        save_baseline(measurements, path)
+        assert path.exists()
+        data = json.loads(path.read_text())
+        assert data["categories"]["test call"][0]["total"] == pytest.approx(0.3)
+        assert data["categories"]["test call"][0]["calls"] == 2
+
+
+class TestCompareToBaseline:
+    def test_no_regression(self) -> None:
+        measurements = {
+            Category.TEST_CALL: {
+                "test_foo": [0.9, 0.1],
+            },
+        }
+        baseline = {"test call": {"test_foo": 1.0}}
+        regressions = compare_to_baseline(measurements, baseline, threshold=0.1)
+        assert regressions == []
+
+    def test_regression_detected(self) -> None:
+        measurements = {
+            Category.TEST_CALL: {
+                "test_foo": [1.5],
+            },
+        }
+        baseline = {"test call": {"test_foo": 1.0}}
+        regressions = compare_to_baseline(measurements, baseline, threshold=0.1)
+        assert len(regressions) == 1
+        assert regressions[0]["delta"] == 0.5
+
+    def test_new_test_ignored(self) -> None:
+        measurements = {
+            Category.TEST_CALL: {
+                "test_bar": [2.0],
+            },
+        }
+        baseline = {"test call": {}}
+        regressions = compare_to_baseline(measurements, baseline, threshold=0.1)
+        assert regressions == []
+
+    def test_sort_order(self) -> None:
+        measurements = {
+            Category.TEST_CALL: {
+                "test_a": [2.0],
+                "test_b": [1.5],
+            },
+        }
+        baseline = {"test call": {"test_a": 1.0, "test_b": 1.0}}
+        regressions = compare_to_baseline(measurements, baseline, threshold=0.1)
+        assert [r["name"] for r in regressions] == ["test_a", "test_b"]
+
+
+class TestFormatGithubAnnotation:
+    def test_format(self) -> None:
+        regression = {
+            "category": "test_call",
+            "name": "test_foo",
+            "baseline": 1.0,
+            "current": 1.5,
+            "delta": 0.5,
+        }
+        annotation = format_github_annotation(regression)
+        assert "::warning title=Duration Regression::" in annotation
+        assert "test_call" in annotation
+        assert "test_foo" in annotation
+        assert "50.0%" in annotation

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -39,7 +39,7 @@ def fake_config(fake_pluginmanager):
 def test_pytest_addoption(fake_parser, fake_pluginmanager):
     pytest_addoption(fake_parser, fake_pluginmanager)
     assert fake_parser.getgroup.called is True
-    assert fake_parser.getgroup.return_value.addoption.call_count == 7
+    assert fake_parser.getgroup.return_value.addoption.call_count == 10
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #58

- New options: --pytest-durations-baseline, --pytest-durations-baseline-threshold,
  --pytest-durations-save-baseline
- Load baseline JSON and compare current run against it
- Report regressions in terminal summary with delta percentages
- Emit GitHub Actions workflow annotations when running in CI
- Comprehensive test coverage for baseline module