### PR TITLE
Release 1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ $ pytest
 
 ## Unreleased
 
+*Nothing unreleased yet.*
+
 ## Change Log
 
 ### 1.9.0 (Aug 14, 2026)

--- a/README.md
+++ b/README.md
@@ -138,12 +138,14 @@ $ pytest
 
 ## Unreleased
 
+## Change Log
+
+### 1.9.0 (Aug 14, 2026)
+
 * Improved CI/CD: split lint/test jobs, added Poetry caching, wheel smoke-test, and ARCHITECTURE.md (#61).
 * Improved test coverage by adding missing assertions (#56).
-* Added --pytest-durations-json option to export timing data as JSON for CI integration and programmatic consumption (#60).
-* Added p90, p95, p99 percentile columns to duration reports via --pytest-durations-columns (#57).
-
-## Change Log
+* Added `--pytest-durations-json` option to export timing data as JSON for CI integration and programmatic consumption (#60).
+* Added `p90`, `p95`, `p99` percentile columns to duration reports via `--pytest-durations-columns` (#57).
 
 ### 1.8.0 (Aug 07, 2026)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pytest-durations"
-version = "1.8.0"
+version = "1.9.0"
 description = "Pytest plugin reporting fixtures and test functions execution time."
 authors = ["Oleg Blednov <oleg.codev@gmail.com>"]
 license = "MIT"

--- a/src/pytest_durations/__init__.py
+++ b/src/pytest_durations/__init__.py
@@ -2,4 +2,4 @@
 
 from pytest_durations.options import pytest_addoption, pytest_configure  # noqa: F401
 
-__version__ = "1.8.0"
+__version__ = "1.9.0"


### PR DESCRIPTION
Bump version to 1.9.0.

### New Features
- `--pytest-durations-json` — export timing data as JSON for CI integration (#60)
- `p90, p95, p99` percentile columns in duration reports (#57)

### Other Changes
- Improved test coverage (#56)
- CI/CD enhancements: split lint/test jobs, Poetry caching, wheel smoke-test, ARCHITECTURE.md (#61)

All 133 tests pass locally.